### PR TITLE
SH is not BASH, so we maybe have no "source" buildin function

### DIFF
--- a/launch-container.sh
+++ b/launch-container.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 SRC=$(cd $(dirname "$0"); pwd)
-source "${SRC}/conf/conf.sh"
+. "${SRC}/conf/conf.sh"
 
 docker run -p 8081:8081 -p 80:80 -p 443:443 -d -it --hostname=passbolt.docker --name passbolt \
     -v $PASSBOLT_DIR:/var/www/passbolt \


### PR DESCRIPTION
The function "source" is only available in Bash and not in a regular SH.