### PR TITLE
Fix issue with send-anonymous-statistics

### DIFF
--- a/entry-point.sh
+++ b/entry-point.sh
@@ -115,7 +115,7 @@ fi
 # Install passbolt
 if [ $IS_PASSBOLT_INSTALLED == "0" ]; then
     echo "Installing"
-    su -s /bin/bash -c "/var/www/passbolt/app/Console/cake install --admin-username ${ADMIN_USERNAME} --admin-first-name=${ADMIN_FIRST_NAME} --admin-last-name=${ADMIN_LAST_NAME}" www-data
+    su -s /bin/bash -c "/var/www/passbolt/app/Console/cake install --admin-username ${ADMIN_USERNAME} --admin-first-name=${ADMIN_FIRST_NAME} --admin-last-name=${ADMIN_LAST_NAME} --send-anonymous-statistics=false" www-data
     echo "We are all set. Have fun with Passbolt !"
     echo "Reminder : THIS IS A DEMO CONTAINER. DO NOT USE IT IN PRODUCTION!!!!"
 fi


### PR DESCRIPTION
The problem is during the boot and configuration process it asking if we would like to send statistics. The is no interactive shell provided in the docker containter.