### PR TITLE
adapt gpg generation to be compatible with gnupg > 2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ If you don't configure a smtp server, emails notifications won't be sent. User w
 	docker build -t passbolt_debian .
 	./launch-container.sh
 ```
+
+6) To gain access to the application with the domain name passbolt.docker you must add an alias on your system targeting the passbolt container.
+
+```
+sudo sh -c 'echo "$(docker inspect --format='{{.NetworkSettings.Networks.bridge.IPAddress}}' passbolt) passbolt.docker" >> /etc/hosts'
+```
+
+7) Registration ending
 If a smtp server has been configured you will receive a registration email at the email you defined in the conf.sh file.
 
 If no smtp server has been configured, you can still finalize the registration process. Take a look at the end of the docker logs,

--- a/bin/generate_gpg_server_key.sh
+++ b/bin/generate_gpg_server_key.sh
@@ -2,5 +2,7 @@
 
 DIRNAME=`dirname $0`/..
 gpg --batch --armor --gen-key $DIRNAME/conf/gpg_server_key_settings.conf
+gpg --armor --output $DIRNAME/gpg_server_key_private.key --export-secret-keys "$(cat $DIRNAME/conf/gpg_server_key_settings.conf | grep Name-Real | awk -F: '{gsub(/^[ \t]+|[ \t]+$/, "", $2); print $2}')"
+gpg --armor --output conf/gpg_server_key_public.key --export "$(gpg --list-packets conf/gpg_server_key_private.key | grep keyid | awk -F: 'NR==1 {gsub(/^[ \t]+|[ \t]+$/, "", $2); print $2}')"
 mv $DIRNAME/gpg_server_key_public.key $DIRNAME/conf
 mv $DIRNAME/gpg_server_key_private.key $DIRNAME/conf

--- a/conf/gpg_server_key_settings.conf
+++ b/conf/gpg_server_key_settings.conf
@@ -6,7 +6,7 @@ Name-Real: Passbolt Docker Server Key
 Name-Comment: Passbolt Docker Server Key
 Name-Email: info@passbolt.com
 Expire-Date: 0
-%pubring gpg_server_key_public.key
-%secring gpg_server_key_private.key
+%no-ask-passphrase
+%no-protection
 %commit
 %echo Your gpg passbolt server key has been generated

--- a/entry-point.sh
+++ b/entry-point.sh
@@ -63,6 +63,8 @@ cp -a /var/www/passbolt/app/Config/core.php.default /var/www/passbolt/app/Config
 cp -a /var/www/passbolt/app/webroot/js/app/config/config.json.default /var/www/passbolt/app/webroot/js/app/config/config.json
 
 # gpg
+#Init gpg directory
+gpg --fingerprint
 GPG_SERVER_KEY_FINGERPRINT=`gpg -n --with-fingerprint /home/www-data/gpg_server_key_public.key | awk -v FS="=" '/Key fingerprint =/{print $2}' | sed 's/[ ]*//g'`
 /var/www/passbolt/app/Console/cake passbolt app_config write GPG.serverKey.fingerprint $GPG_SERVER_KEY_FINGERPRINT
 /var/www/passbolt/app/Console/cake passbolt app_config write GPG.serverKey.public /home/www-data/gpg_server_key_public.key
@@ -73,7 +75,7 @@ chown www-data:www-data /home/www-data/gpg_server_key_private.key
 # overwrite the core configuration
 /var/www/passbolt/app/Console/cake passbolt core_config gen-cipher-seed
 /var/www/passbolt/app/Console/cake passbolt core_config gen-security-salt
-/var/www/passbolt/app/Console/cake passbolt core_config write App.fullBaseUrl https://192.168.99.100
+/var/www/passbolt/app/Console/cake passbolt core_config write App.fullBaseUrl ${APP_URL}
 
 # overwrite the database configuration
 # @TODO based on the cake task DbConfigTask implement a task to manipulate the dabase configuration

--- a/launch-container.sh
+++ b/launch-container.sh
@@ -5,7 +5,7 @@ source "${SRC}/conf/conf.sh"
 
 docker run -p 8081:8081 -p 80:80 -p 443:443 -d -it --hostname=passbolt.docker --name passbolt \
     -v $PASSBOLT_DIR:/var/www/passbolt \
-    -e APP_URL=https://192.168.99.100 \
+    -e APP_URL=https://passbolt.docker \
     -e MYSQL_HOST=$MYSQL_HOST \
     -e MYSQL_ROOT_PASSWORD=$MYSQL_ROOT_PASSWORD \
     -e MYSQL_USERNAME=$MYSQL_USERNAME \


### PR DESCRIPTION
Implementation of the installation process described at : https://www.passbolt.com/help/tech/install, but with a container
+ application exposed on the domain name passbolt.docker