### PR TITLE
Install raspberry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM {PLATFORM}alpine:latest
+FROM ${platform}alpine:latest
 
 MAINTAINER diego@passbolt.com
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM {PLATFORM}alpine:latest
 
 MAINTAINER diego@passbolt.com
 

--- a/Dockerfile.raspberry
+++ b/Dockerfile.raspberry
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM armhf/alpine:latest
 
 MAINTAINER diego@passbolt.com
 

--- a/README-raspberry.md
+++ b/README-raspberry.md
@@ -1,0 +1,14 @@
+# Passbolt on the RaspberryPI
+
+In order to build and run the Passbolt Docker images on a RaspberryPI, do the following:
+
+```
+$ cd raspberry
+$ sudo ./install.sh
+$ sudo ./startup.sh
+```
+
+If all goes well, you should be able to access Passvolt by visiting `https://raspberrypi-ip-address`
+from any computer on the network.
+
+It should run fine on Raspbian, as well as derivative distributions.

--- a/README-raspberry.md
+++ b/README-raspberry.md
@@ -8,7 +8,7 @@ $ sudo ./install.sh
 $ sudo ./startup.sh
 ```
 
-If all goes well, you should be able to access Passvolt by visiting `https://raspberrypi-ip-address`
+If all goes well, you should be able to access Passbolt by visiting `https://raspberrypi-ip-address`
 from any computer on the network.
 
 It should run fine on Raspbian, as well as derivative distributions.

--- a/raspberry/install.sh
+++ b/raspberry/install.sh
@@ -29,10 +29,10 @@ function build_passbolt() {
 
     image_passbolt=`docker images -qa "$container_passbolt"`
     if [ "$image_passbolt" != "" ]; then
-	echo "Passbolt image already built: $image_passbolt"
+        echo "Passbolt image already built: $image_passbolt"
     else
-	# Generate Docker and mysql containers
-	cd .. && docker build . --file Dockerfile.raspberry -t $container_passbolt
+        # Generate Docker and mysql containers
+        cd .. && docker build . --file Dockerfile.raspberry -t $container_passbolt
     fi
 }
 

--- a/raspberry/install.sh
+++ b/raspberry/install.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+#
+#  This script will install passbolt Docker on the RaspberryPI
+#
+#  You must use Raspbian or a derivative distro.
+#  Tested on pipaos: http://pipaos.mitako.eu/
+#
+
+function prerequisites() {
+    # Install docker if needed
+    if [ `which docker` != 0 ]; then
+        curl -sSL https://get.docker.com | sh
+        if  [ $? != 0 ]; then
+            echo "Could not install Docker"
+            exit 1
+        fi
+    fi
+    
+    # Passbolt docker needs enthropy to generate ssh keys
+    if [ `which rng-tools` != 0 ]; then
+        sudo apt-get install -y rng-tools
+    fi
+}
+
+function download_images() {
+
+    docker pull armhf/alpine
+    docker pull blabla/mysql-armhf
+
+}
+
+
+if [ `uid` != 0 ]; then
+    echo "You must run this script as root"
+    exit 1
+fi
+
+required_software
+download_images
+
+# Generate Docker and mysql containers
+PLATFORM="armhf/" docker .. -t passbolt:1.4.0-alpine
+
+# bring up the mysql docker instance
+# TODO: start in the background
+run.sh
+
+# Start passbolt container
+# TODO: ??? find the mysql container ip address (docker inspect)
+docker run -e db_host=??? passbolt:1.4.0-alpine

--- a/raspberry/install.sh
+++ b/raspberry/install.sh
@@ -13,13 +13,14 @@ source ./pivars
 function required_software() {
 
     # Install docker if needed
-    which docker || echo "curl -sSL https://get.docker.com | sh"
+    which docker || curl -sSL https://get.docker.com | sh
 
     # Passbolt docker needs entropy to generate ssh keys
     which rngd || sudo apt-get install -y rng-tools
 }
 
 function required_images() {
+
     docker image inspect $image_alpine | grep "Id" || docker pull $image_alpine
     docker image inspect $image_mysql | grep "Id"  || docker pull $image_mysql
 }
@@ -27,12 +28,11 @@ function required_images() {
 function build_passbolt() {
 
     image_passbolt=`docker images -qa "$container_passbolt"`
-    if [ "$image_passbolt" != "b5bf3d67c085" ]; then
+    if [ "$image_passbolt" != "" ]; then
 	echo "Passbolt image already built: $image_passbolt"
     else
 	# Generate Docker and mysql containers
-	# FIXME: pass platform name correctly
-	PLATFORM="armhf/" docker build .. -t $container_passbolt
+	cd .. && docker build . --file Dockerfile.raspberry -t $container_passbolt
     fi
 }
 

--- a/raspberry/pivars
+++ b/raspberry/pivars
@@ -1,0 +1,10 @@
+#!/bin/bash
+#
+# Common variables for the RaspberryPI
+#
+
+# From https://hub.docker.com/
+image_alpine="armhf/alpine"
+image_mysql="hypriot/rpi-mysql"
+
+container_passbolt="passbolt:1.4.0-alpine"

--- a/raspberry/startup.sh
+++ b/raspberry/startup.sh
@@ -11,28 +11,33 @@ source pivars
 
 function start_mysql() {
 
-    echo "Starting $image_mysql..."
-    docker run -d -e MYSQL_ROOT_PASSWORD="" \
-       -e MYSQL_ALLOW_EMPTY_PASSWORD=1 \
-       -e MYSQL_RANDOM_ROOT_PASSWORD=1 \
-       -e MYSQL_DATABASE=passbolt \
-       -e MYSQL_USER=passbolt \
-       -e MYSQL_PASSWORD=P4ssb0lt \
-       $image_mysql
+    id_mysql=`docker ps -aq --filter ancestor=$image_mysql --filter status=running`
+    if [ "$id_mysql" != "" ]; then
+	echo "$image_mysql is already running $id_mysql"
+    else
+	echo "Starting $image_mysql..."
+	docker run -d -e MYSQL_ROOT_PASSWORD="" \
+	       -e MYSQL_ALLOW_EMPTY_PASSWORD=1 \
+	       -e MYSQL_RANDOM_ROOT_PASSWORD=1 \
+	       -e MYSQL_DATABASE=passbolt \
+	       -e MYSQL_USER=passbolt \
+	       -e MYSQL_PASSWORD=P4ssb0lt \
+	       $image_mysql
 
-    sleep 5
+	sleep 5
+    fi
 }
 
 function start_passbolt() {
 
     id_passbolt=`docker ps -aq --filter ancestor=$container_passbolt --filter status=running`
     if [ "$id_passbolt" != "" ]; then
-	echo "Passbolt container is already running $id_passbolt"
+	echo "$container_passbolt is already running $id_passbolt"
     else
 	id_mysql=`docker ps -aq --filter ancestor=$image_mysql --filter status=running`
 	ipaddress=`docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $id_mysql`
 	echo "Starting $container_passbolt container binding IP=$ipaddress"
-	docker run -d -e db_host=$ipaddress $container_passbolt
+	docker run -d -p 80:80 -p 443:443 -e db_host=$ipaddress $container_passbolt
     fi
 }
 

--- a/raspberry/startup.sh
+++ b/raspberry/startup.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+#
+# Script to start the containers
+#
+
+set -e
+
+source rpi_variables
+
+function start_mysql() {
+
+    docker run -e MYSQL_ROOT_PASSWORD="" \
+       -e MYSQL_ALLOW_EMPTY_PASSWORD=1 \
+       -e MYSQL_RANDOM_ROOT_PASSWORD=1 \
+       -e MYSQL_DATABASE=passbolt \
+       -e MYSQL_USER=passbolt \
+       -e MYSQL_PASSWORD=P4ssb0lt \
+       $image_mysql
+}
+
+function start_passbolt() {
+
+    image_passbolt=`docker images $container_passbolt"`
+    if [ "$image_passbolt" != "" ]; then
+	echo "Passbolt container already built: $id_passbolt"
+    else
+	id_mysql=`docker ps -aq --filter ancestor=$image_mysql --filter status=running`
+	ip=`docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $id_mysql`
+	echo "id=$id_mysql ip=$ip"
+	#docker run -e db_host=??? $container_passbolt
+    fi
+}
+
+
+# Start the passbolt container
+# TODO: move below steps to an external script
+start_mysql
+start_passbolt

--- a/raspberry/startup.sh
+++ b/raspberry/startup.sh
@@ -2,37 +2,41 @@
 #
 # Script to start the containers
 #
+# WARNING:The session used to run this script must stay alive all the time.
+#
 
 set -e
 
-source rpi_variables
+source pivars
 
 function start_mysql() {
 
-    docker run -e MYSQL_ROOT_PASSWORD="" \
+    echo "Starting $image_mysql..."
+    docker run -d -e MYSQL_ROOT_PASSWORD="" \
        -e MYSQL_ALLOW_EMPTY_PASSWORD=1 \
        -e MYSQL_RANDOM_ROOT_PASSWORD=1 \
        -e MYSQL_DATABASE=passbolt \
        -e MYSQL_USER=passbolt \
        -e MYSQL_PASSWORD=P4ssb0lt \
        $image_mysql
+
+    sleep 5
 }
 
 function start_passbolt() {
 
-    image_passbolt=`docker images $container_passbolt"`
-    if [ "$image_passbolt" != "" ]; then
-	echo "Passbolt container already built: $id_passbolt"
+    id_passbolt=`docker ps -aq --filter ancestor=$container_passbolt --filter status=running`
+    if [ "$id_passbolt" != "" ]; then
+	echo "Passbolt container is already running $id_passbolt"
     else
 	id_mysql=`docker ps -aq --filter ancestor=$image_mysql --filter status=running`
-	ip=`docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $id_mysql`
-	echo "id=$id_mysql ip=$ip"
-	#docker run -e db_host=??? $container_passbolt
+	ipaddress=`docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $id_mysql`
+	echo "Starting $container_passbolt container binding IP=$ipaddress"
+	docker run -d -e db_host=$ipaddress $container_passbolt
     fi
 }
 
 
-# Start the passbolt container
-# TODO: move below steps to an external script
+# Start mysql and passbolt containers
 start_mysql
 start_passbolt

--- a/raspberry/startup.sh
+++ b/raspberry/startup.sh
@@ -13,18 +13,18 @@ function start_mysql() {
 
     id_mysql=`docker ps -aq --filter ancestor=$image_mysql --filter status=running`
     if [ "$id_mysql" != "" ]; then
-	echo "$image_mysql is already running $id_mysql"
+        echo "$image_mysql is already running $id_mysql"
     else
-	echo "Starting $image_mysql..."
-	docker run -d -e MYSQL_ROOT_PASSWORD="" \
-	       -e MYSQL_ALLOW_EMPTY_PASSWORD=1 \
-	       -e MYSQL_RANDOM_ROOT_PASSWORD=1 \
-	       -e MYSQL_DATABASE=passbolt \
-	       -e MYSQL_USER=passbolt \
-	       -e MYSQL_PASSWORD=P4ssb0lt \
-	       $image_mysql
+        echo "Starting $image_mysql..."
+        docker run -d -e MYSQL_ROOT_PASSWORD="" \
+               -e MYSQL_ALLOW_EMPTY_PASSWORD=1 \
+               -e MYSQL_RANDOM_ROOT_PASSWORD=1 \
+               -e MYSQL_DATABASE=passbolt \
+               -e MYSQL_USER=passbolt \
+               -e MYSQL_PASSWORD=P4ssb0lt \
+               $image_mysql
 
-	sleep 5
+        sleep 5
     fi
 }
 
@@ -32,15 +32,14 @@ function start_passbolt() {
 
     id_passbolt=`docker ps -aq --filter ancestor=$container_passbolt --filter status=running`
     if [ "$id_passbolt" != "" ]; then
-	echo "$container_passbolt is already running $id_passbolt"
+        echo "$container_passbolt is already running $id_passbolt"
     else
-	id_mysql=`docker ps -aq --filter ancestor=$image_mysql --filter status=running`
-	ipaddress=`docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $id_mysql`
-	echo "Starting $container_passbolt container binding IP=$ipaddress"
-	docker run -d -p 80:80 -p 443:443 -e db_host=$ipaddress $container_passbolt
+        id_mysql=`docker ps -aq --filter ancestor=$image_mysql --filter status=running`
+        ipaddress=`docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $id_mysql`
+        echo "Starting $container_passbolt container binding IP=$ipaddress"
+        docker run -d -p 80:80 -p 443:443 -e db_host=$ipaddress $container_passbolt
     fi
 }
-
 
 # Start mysql and passbolt containers
 start_mysql


### PR DESCRIPTION
This changeset provides two additional scripts that allow to create the Passbolt images on the RaspberryPI, and launch the software, respectively, so it can be automated at boot time. It will also install the complete Docker software if needed.

The end result will get the Passbolt and Mysql Docker instances running on the PI, which can then be accessed from any networked computer through a regular web browser.

Tested to run fine on [pipaOS](http://pipaos.mitako.eu/) but should also work on Raspbian.

@dlen 
