### PR TITLE
Allow no db environment variable setting

### DIFF
--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -130,8 +130,11 @@ gen_ssl_cert() {
 }
 
 install() {
-  local database=${db_host:-$(grep -m1 -o '[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}' $db_config)}
-  tables=$(mysql -u ${db_user:-passbolt} -h $database -p -BN -e "SHOW TABLES FROM passbolt" -p${db_pass:-P4ssb0lt} |wc -l)
+  local database_host=${db_host:-$(cat $db_config | grep -m1 "'host'" | sed -r "s/\s*'host' => '(.*)',/\1/")}
+  local database_user=${db_user:-$(cat $db_config | grep -m1 "'login'" | sed -r "s/\s*'login' => '(.*)',/\1/")}
+  local database_pass=${db_user:-$(cat $db_config | grep -m1 "'password'" | sed -r "s/\s*'password' => '(.*)',/\1/")}
+  local database_name=${db_name:-$(cat $db_config | grep -m1 "'database'" | sed -r "s/\s*'database' => '(.*)',/\1/")}
+  tables=$(mysql -u ${database_user:-passbolt} -h $database_host -p -BN -e "SHOW TABLES FROM ${database_name:-passbolt}" -p${database_pass:-P4ssb0lt} |wc -l)
 
   if [ $tables -eq 0 ]; then
     su -c "/var/www/passbolt/app/Console/cake install --send-anonymous-statistics true --no-admin" -ls /bin/bash nginx

--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -132,7 +132,7 @@ gen_ssl_cert() {
 install() {
   local database_host=${db_host:-$(cat $db_config | grep -m1 "'host'" | sed -r "s/\s*'host' => '(.*)',/\1/")}
   local database_user=${db_user:-$(cat $db_config | grep -m1 "'login'" | sed -r "s/\s*'login' => '(.*)',/\1/")}
-  local database_pass=${db_user:-$(cat $db_config | grep -m1 "'password'" | sed -r "s/\s*'password' => '(.*)',/\1/")}
+  local database_pass=${db_pass:-$(cat $db_config | grep -m1 "'password'" | sed -r "s/\s*'password' => '(.*)',/\1/")}
   local database_name=${db_name:-$(cat $db_config | grep -m1 "'database'" | sed -r "s/\s*'database' => '(.*)',/\1/")}
   tables=$(mysql -u ${database_user:-passbolt} -h $database_host -p -BN -e "SHOW TABLES FROM ${database_name:-passbolt}" -p${database_pass:-P4ssb0lt} |wc -l)
 


### PR DESCRIPTION
In the case someone wants to configure passbolt using config files (as stated in the [Advanced configuration](https://github.com/passbolt/passbolt_docker#advanced-configuration-1) of the README), this PR allows to avoid setting DB environment variables.