### PR TITLE
Allow Config files to be symbolic links

### DIFF
--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -173,29 +173,31 @@ email_cron_job() {
 }
 
 
-if [ ! -e $gpg_private_key ] || [ ! -e $gpg_public_key ]; then
+if [ ! -f $gpg_private_key ] && [ ! -L $gpg_private_key ] || \
+   [ ! -f $gpg_public_key ] && [ ! -L $gpg_public_key ]; then
   gpg_gen_key
 else
   gpg_import_key
 fi
 
-if [ ! -e $core_config ]; then
+if [ ! -f $core_config ] && [ ! -L $core_config ]; then
   core_setup
 fi
 
-if [ ! -e $db_config ]; then
+if [ ! -f $db_config ] && [ ! -L $db_config ]; then
   db_setup
 fi
 
-if [ ! -e $app_config ]; then
+if [ ! -f $app_config ] && [ ! -L $app_config ]; then
   app_setup
 fi
 
-if [ ! -e $email_config ]; then
+if [ ! -f $email_config ] && [ ! -L $email_config ]; then
   email_setup
 fi
 
-if [ ! -e $ssl_key ] && [ ! -e $ssl_cert ]; then
+if [ ! -f $ssl_key ] && [ ! -L $ssl_key ] && \
+   [ ! -f $ssl_cert ] && [ ! -L $ssl_cert ]; then
   gen_ssl_cert
 fi
 

--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -173,29 +173,29 @@ email_cron_job() {
 }
 
 
-if [ ! -f $gpg_private_key ] || [ ! -f $gpg_public_key ]; then
+if [ ! -e $gpg_private_key ] || [ ! -e $gpg_public_key ]; then
   gpg_gen_key
 else
   gpg_import_key
 fi
 
-if [ ! -f $core_config ]; then
+if [ ! -e $core_config ]; then
   core_setup
 fi
 
-if [ ! -f $db_config ]; then
+if [ ! -e $db_config ]; then
   db_setup
 fi
 
-if [ ! -f $app_config ]; then
+if [ ! -e $app_config ]; then
   app_setup
 fi
 
-if [ ! -f $email_config ]; then
+if [ ! -e $email_config ]; then
   email_setup
 fi
 
-if [ ! -f $ssl_key ] && [ ! -f $ssl_cert ]; then
+if [ ! -e $ssl_key ] && [ ! -e $ssl_cert ]; then
   gen_ssl_cert
 fi
 


### PR DESCRIPTION
The `-f` operator checks if a files exists and i must not be a symlink, however this creates problems when using tool like Kubernetes.
When using the `-e` option it will be checked if the file exist regardless of it's type.