### PR TITLE
change to LABEL, add docker-compose file for testing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.6
 
-MAINTAINER diego@passbolt.com
+LABEL maintainer "diego@passbolt.com"
 
 ENV PASSBOLT_VERSION 1.6.3
 ENV PASSBOLT_URL https://github.com/passbolt/passbolt_api/archive/v${PASSBOLT_VERSION}.tar.gz

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+version: '3'
+
+services:
+   db:
+     image: mysql:5.7
+     container_name: db
+     volumes:
+       - db_data:/var/lib/mysql
+     restart: always
+     environment:
+       MYSQL_ROOT_PASSWORD: "P4ssb0lt"
+       MYSQL_DATABASE: "passbolt"
+       MYSQL_USER: "passbolt"
+       MYSQL_PASSWORD: "P4ssb0lt"
+
+   passbolt:
+     depends_on:
+       - db
+     image: passbolt/passbolt
+     container_name: passbolt
+     ports:
+       - "443:443"
+     restart: always
+     environment:
+       DB_HOST: "db"
+       URL: passbolt.local
+       REGISTRATION: "true"
+volumes:
+    db_data:


### PR DESCRIPTION
i added a docker-compose.yml file for quick tests.
It is IMHO easier, since you don't need the container IP Adress.
It works with DNS, since both containers are in the same network.
I also changed MAINTAINER to LABEL since former is deprecated as of Docker 1.13
https://docs.docker.com/engine/reference/builder/#maintainer-deprecated
