### PR TITLE
turn URL config independent from SSL var

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Passbolt docker image provides several environment variables to configure differ
 
 * SALT:       a random string used by cakephp in security hashing methods
 * CIPHERSEED: a random string used by cakephp to encrypt/decrypt strings
-* URL:        URL of the passbolt installation (defaults to passbolt.local)
+* URL:        URL of the passbolt installation (defaults to http://passbolt.local)
 
 ### Database variables
 

--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -45,16 +45,13 @@ core_setup() {
 
   local default_salt='DYhG93b0qyJfIxfs2guVoUubWwvniR2G0FgaC9mi'
   local default_seed='76859309657453542496749683645'
-  local default_url='passbolt.local'
+  local default_url='http://passbolt.local'
 
   cp $core_config{.default,}
   sed -i s:$default_salt:${SALT:-$default_salt}:g $core_config
   sed -i s:$default_seed:${CIPHERSEED:-$default_seed}:g $core_config
   sed -i "/example.com/ s:\/\/::" $core_config
-  sed -i s:example.com:${URL:-$default_url}:g $core_config
-  if [ "${SSL:-true}" != false ]; then
-    sed -i s:http:https:g $core_config
-  fi
+  sed -i "s|http://example.com|${URL:-$default_url}|g" $core_config
 }
 
 db_setup() {


### PR DESCRIPTION
At my company everything must be behind one reverse proxy (that has the certificate for our domain).

In order to have the `fullBaseUrl` with https, you need to set the `SSL` environment variable to true.

But this also enables the "ssl force" to true. And this doesn't work behind a reverse proxy.

So I changed the `URL` environment variable to be the `fullBaseUrl`, and not just some part of it.