### PR TITLE
Add environment variable to set email client

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Passbolt docker image provides several environment variables to configure differ
 * EMAIL_AUTH:      disable smtp auth              ( defaults to true)
 * EMAIL_USERNAME:  username for email server auth ( defaults to email_user)
 * EMAIL_PASSWORD:  password for email server auth ( defaults to email_password)
+* EMAIL_CLIENT:    hostname to send as smtp helo  ( defaults to null)
 * EMAIL_TLS:       set tls, boolean               ( defaults to false)
 
 ## Advanced configuration

--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -109,6 +109,7 @@ email_setup() {
   # EMAIL_AUTH
   # EMAIL_USERNAME
   # EMAIL_PASSWORD
+  # EMAIL_CLIENT
   # EMAIL_TLS
 
   local default_transport='Smtp'
@@ -118,6 +119,7 @@ email_setup() {
   local default_timeout='30'
   local default_username="''"
   local default_password="''"
+  local default_client=null
 
   cp $email_config{.default,}
   sed -i s:$default_transport:${EMAIL_TRANSPORT:-Smtp}:g $email_config
@@ -132,7 +134,9 @@ email_setup() {
   	sed -i "0,/"$default_username"/s:"$default_username":'${EMAIL_USERNAME:-email_user}':" $email_config
 	sed -i "0,/"$default_password"/s:"$default_password":'${EMAIL_PASSWORD:-email_password}':" $email_config
   fi
-  
+  if [ -n "$EMAIL_CLIENT" ] ; then
+    sed -i "0,/"$default_client"/s:"$default_client":'$EMAIL_CLIENT':" $email_config
+  fi
   sed -i "0,/tls/s:false:${EMAIL_TLS:-false}:" $email_config
 
 }


### PR DESCRIPTION
The 'client' setting control what the Smtp client sends as EHLO/HELO
message to the smtp-server, this change allows the behaviour to be
controlled via environment variable instead of having to mount your
own email.php file.

This change requires that
https://github.com/passbolt/passbolt_api/pull/209 is merged.