### PR TITLE
Fix bug in how the email 'client' is edited.

### DIFF
--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -132,7 +132,7 @@ email_setup() {
 	sed -i "0,/"$default_password"/s:"$default_password":'${EMAIL_PASSWORD:-email_password}':" $email_config
   fi
   if [ -n "$EMAIL_CLIENT" ] ; then
-    sed -i "0,/"$default_client"/s:"$default_client":'$EMAIL_CLIENT':" $email_config
+    sed -i "0,/'client'/s:'client' => $default_client:'client' => '$EMAIL_CLIENT':" $email_config
   fi
   sed -i "0,/tls/s:false:${EMAIL_TLS:-false}:" $email_config
 


### PR DESCRIPTION
We must match the entire row to make sure to search/replace the correct
place when other values collide with the specified default.

In this instance, if EMAIL_AUTH is false, both username and password
gets specified to 'null', which was previously included in seds range
for searching-and-replacing 'null' occurances to EMAIL_CLIENT.