### PR TITLE
Replace php copy with curl for use with proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ RUN apt-get update \
     && docker-php-ext-enable $PHP_EXTENSIONS $PECL_PASSBOLT_EXTENSIONS \
     && docker-php-source delete \
     && EXPECTED_SIGNATURE=$(curl -s https://composer.github.io/installer.sig) \
-    && php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
+    && curl -o composer-setup.php https://getcomposer.org/installer \
     && ACTUAL_SIGNATURE=$(php -r "echo hash_file('SHA384', 'composer-setup.php');") \
     && if [ "$EXPECTED_SIGNATURE" != "$ACTUAL_SIGNATURE" ]; then \
          >&2 echo 'ERROR: Invalid installer signature'; \


### PR DESCRIPTION
php `copy` connects directly...it does not use the specified `https_proxy` or `http_proxy` environment variables. A third parameter can be added to `copy` to use the proxy, but this needlessly complicates things. Replacing `copy` with `curl` enables the use of preset proxy environment variables.