### PR TITLE
Pin mariadb version

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,7 +1,7 @@
 version: '3.4'
 services:
   db:
-    image: mariadb:latest
+    image: mariadb:10.3
     env_file:
       - env/mysql.env
     volumes:

--- a/docker-compose-pro.yml
+++ b/docker-compose-pro.yml
@@ -1,7 +1,7 @@
 version: '3.4'
 services:
   db:
-    image: mariadb:latest
+    image: mariadb:10.3
     env_file:
       - env/mysql.env
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.4'
 services:
   db:
-    image: mariadb:latest
+    image: mariadb:10.3
     env_file:
       - env/mysql.env
     volumes:


### PR DESCRIPTION
Using `latest` version tags is usually not a good idea, especially for production environments.

This PR pin mariadb to the current major/minor image version, while allowing later security patches to be applied.

This does means that as Mariadb release new versions, they should be tested against passbolt current version and those tags updated.