### PR TITLE
hide nginx and php version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,7 +75,9 @@ RUN apt-get update \
     && rm /etc/nginx/sites-enabled/default \
     && apt-get purge -y --auto-remove $PASSBOLT_DEV_PACKAGES \
     && rm -rf /var/lib/apt/lists/* \
-    && rm /usr/local/bin/composer
+    && rm /usr/local/bin/composer \
+    && echo 'php_flag[expose_php] = off' > /usr/local/etc/php-fpm.d/expose.conf \
+    && sed -i 's/# server_tokens/server_tokens/' /etc/nginx/nginx.conf
 
 COPY conf/passbolt.conf /etc/nginx/conf.d/default.conf
 COPY conf/supervisord.conf /etc/supervisor/supervisord.conf


### PR DESCRIPTION
Hello.
First of all I want to tell many thanks for your work!

### What you did
- git clone repo
- docker-compose up
- edit /etc/hosts
- curl https://passbolt.local -I -k

### What happened
> $ curl https://passbolt.local -I -k
> HTTP/1.1 404 Not Found
> Server: nginx/1.10.3
> Date: Tue, 19 Jun 2018 20:59:33 GMT
> Content-Type: text/html; charset=UTF-8
> Connection: keep-alive
> Keep-Alive: timeout=5
> X-Powered-By: PHP/7.2.6

### What you expected to happen
I expected that the nginx and PHP version will be hidden.