### PR TITLE
add wait-for.sh to Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,5 +8,4 @@ Gemfile.lock
 Rakefile
 *.md
 *.yml
-scripts
 env

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,6 +78,7 @@ RUN apt-get update \
 COPY conf/passbolt.conf /etc/nginx/conf.d/default.conf
 COPY conf/supervisor/*.conf /etc/supervisor/conf.d/
 COPY bin/docker-entrypoint.sh /docker-entrypoint.sh
+COPY scripts/wait-for.sh /usr/bin/wait-for.sh
 
 EXPOSE 80 443
 

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -21,7 +21,6 @@ services:
     volumes:
       - gpg_volume:/var/www/passbolt/config/gpg
       - images_volume:/var/www/passbolt/webroot/img/public/images
-      - ./scripts/wait-for.sh:/usr/bin/wait-for.sh
     command: ["/usr/bin/wait-for.sh", "db:3306", "--", "/docker-entrypoint.sh"]
     ports:
       - 80:80

--- a/docker-compose-pro.yml
+++ b/docker-compose-pro.yml
@@ -20,7 +20,6 @@ services:
       - gpg_volume:/var/www/passbolt/config/gpg
       - images_volume:/var/www/passbolt/webroot/img/public
       - ./license:/var/www/passbolt/config/license
-      - ./scripts/wait-for.sh:/usr/bin/wait-for.sh
     tmpfs:
       - /run
     command: ["/usr/bin/wait-for.sh", "db:3306", "--", "/docker-entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,6 @@ services:
     volumes:
       - gpg_volume:/var/www/passbolt/config/gpg
       - images_volume:/var/www/passbolt/webroot/img/public
-      - ./scripts/wait-for.sh:/usr/bin/wait-for.sh
     tmpfs:
       - /run
     command: ["/usr/bin/wait-for.sh", "db:3306", "--", "/docker-entrypoint.sh"]


### PR DESCRIPTION
I've added the `wait-for.sh` script to the base Docker image. This script is always needed, so it should be bundled with the rest of the components.