### PR TITLE
Add letsencrypt issuer in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,8 @@ ARG PASSBOLT_DEV_PACKAGES="libgpgme11-dev \
       unzip"
 
 ARG PASSBOLT_BASE_PACKAGES="nginx \
+         certbot \
+         python-certbot-nginx \
          gnupg \
          libgpgme11 \
          libmcrypt4 \
@@ -82,6 +84,7 @@ COPY conf/passbolt.conf /etc/nginx/conf.d/default.conf
 COPY conf/supervisor/*.conf /etc/supervisor/conf.d/
 COPY bin/docker-entrypoint.sh /docker-entrypoint.sh
 COPY scripts/wait-for.sh /usr/bin/wait-for.sh
+COPY scripts/letsencrypt-deploy.sh /etc/letsencrypt/renewal-hooks/deploy/deploy.sh
 
 EXPOSE 80 443
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,9 @@ Passbolt docker image provides several environment variables to configure differ
 | PASSBOLT_PLUGINS_IMPORT_ENABLED     | Enable import plugin             | true |
 | PASSBOLT_REGISTRATION_PUBLIC        | Defines if users can register    | false |
 | PASSBOLT_SSL_FORCE                  | Redirects http to https          | true |
-| PASSBOLT_SECURITY_SET_HEADERS       | Send CSP Headers                 | true | | SECURITY_SALT                       | CakePHP security salt            | __SALT__ |
+| PASSBOLT_SECURITY_SET_HEADERS       | Send CSP Headers                 | true | 
+| SECURITY_SALT                       | CakePHP security salt            | __SALT__ |
+| LETSENCRYPT_ENABLED                 | Enable Letsencrypt               | false |
 
 For more env variables supported please check [default.php](https://github.com/passbolt/passbolt_api/blob/master/config/default.php)
 and [app.default.php](https://github.com/passbolt/passbolt_api/blob/master/config/app.default.php)

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Passbolt docker image provides several environment variables to configure differ
 | PASSBOLT_SECURITY_SET_HEADERS       | Send CSP Headers                 | true | 
 | SECURITY_SALT                       | CakePHP security salt            | __SALT__ |
 | LETSENCRYPT_ENABLED                 | Enable Letsencrypt               | false |
+| LETSENCRYPT_PORT                    | Letsencrypt ACME port            | 80 |
 
 For more env variables supported please check [default.php](https://github.com/passbolt/passbolt_api/blob/master/config/default.php)
 and [app.default.php](https://github.com/passbolt/passbolt_api/blob/master/config/app.default.php)

--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -69,6 +69,18 @@ gen_ssl_cert() {
     -keyout $ssl_key -out $ssl_cert
 }
 
+get_letsencrypt_cert() {
+  certbot certonly \
+    --dry-run -vvv \
+    --http-01-port ${LETSENCRYPT_PORT:-80} \
+    --http-01-address 0.0.0.0 \
+    --noninteractive \
+    --standalone \
+    --agree-tos \
+    --email ${PASSBOLT_KEY_EMAIL:-passbolt@yourdomain.com} \
+    --domain $(basename ${APP_FULL_BASE_URL})
+}
+
 install() {
   local app_config="/var/www/passbolt/config/app.php"
 
@@ -103,7 +115,11 @@ fi
 
 if [ ! -f "$ssl_key" ] && [ ! -L "$ssl_key" ] && \
    [ ! -f "$ssl_cert" ] && [ ! -L "$ssl_cert" ]; then
-  gen_ssl_cert
+  if [ "${LETSENCRYPT_ENABLED:-false}" = "true" ]; then 
+     get_letsencrypt_cert
+  else
+    gen_ssl_cert
+  fi
 fi
 
 install

--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -71,7 +71,6 @@ gen_ssl_cert() {
 
 get_letsencrypt_cert() {
   certbot certonly \
-    --dry-run -vvv \
     --http-01-port ${LETSENCRYPT_PORT:-80} \
     --http-01-address 0.0.0.0 \
     --noninteractive \

--- a/env/passbolt.env
+++ b/env/passbolt.env
@@ -1,5 +1,7 @@
 # URL
 APP_FULL_BASE_URL=https://passbolt.local
+LETSENCRYPT_ENABLED=false
+LETSENCRYPT_PORT=80
 
 # Database settings
 DATASOURCES_DEFAULT_HOST=db

--- a/scripts/letsencrypt-deploy.sh
+++ b/scripts/letsencrypt-deploy.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+cp -v /etc/letsencrypt/live/${CERTBOT_DOMAIN}/cert.pem /etc/ssl/certs/certificate.crt
+cp -v /etc/letsencrypt/live/${CERTBOT_DOMAIN}/privkey.pem /etc/ssl/certs/certificate.key
+/etc/init.d/nginx reload


### PR DESCRIPTION
This feature will enable users to get a letsencrypt SSL certificate inside the docker image. 

New introducen ENV vars: 
- LETSENCRYPT_ENABLED => Enable Letsencrypt
- LETSENCRYPT_PORT => Letsencrypt ACME port