### PR TITLE
Remove port exposure

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -6,8 +6,6 @@ services:
       - env/mysql.env
     volumes:
       - database_volume:/var/lib/mysql
-    ports:
-      - "127.0.0.1:3306:3306"
 
   passbolt:
     build:
@@ -15,6 +13,8 @@ services:
       args:
         PECL_PASSBOLT_EXTENSIONS: "redis gnupg xdebug"
     depends_on:
+      - db
+    links:
       - db
     env_file:
       - env/passbolt.env

--- a/docker-compose-pro.yml
+++ b/docker-compose-pro.yml
@@ -6,8 +6,6 @@ services:
       - env/mysql.env
     volumes:
       - database_volume:/var/lib/mysql
-    ports:
-      - "127.0.0.1:3306:3306"
 
   passbolt:
     image: passbolt/passbolt:latest-pro
@@ -15,6 +13,8 @@ services:
     #image: passbolt/passbolt:latest-pro-non-root
     tty: true
     depends_on:
+      - db
+    links:
       - db
     env_file:
       - env/passbolt.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,6 @@ services:
       - env/mysql.env
     volumes:
       - database_volume:/var/lib/mysql
-    ports:
-      - "127.0.0.1:3306:3306"
 
   passbolt:
     image: passbolt/passbolt:latest-ce
@@ -15,6 +13,8 @@ services:
     #image: passbolt/passbolt:latest-ce-non-root
     tty: true
     depends_on:
+      - db
+    links:
       - db
     env_file:
       - env/passbolt.env


### PR DESCRIPTION
The dockerfiles unneccessarily expose the database container ports on the host machine (which could already be in use). See [here](https://github.com/passbolt/passbolt_docker/blob/master/docker-compose-pro.yml#L10).
It would be better to use `links` to connect to the db container