### PR TITLE
Update Dockerfile

### DIFF
--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.gitlab.com/passbolt/passbolt-ci-docker-images/debian-bullseye-11-slim:latest
+FROM debian:bullseye-slim
 
 LABEL maintainer="Passbolt SA <contact@passbolt.com>"
 


### PR DESCRIPTION
Using registry.gitlab.com/passbolt/passbolt-ci-docker-images/debian-bullseye-11-slim:latest you get the following error:

ERROR: Service 'passbolt' failed to build: Head "https://registry.gitlab.com/v2/passbolt/passbolt-ci-docker-images/debian-bullseye-11-slim/manifests/latest": denied: access forbidden