### PR TITLE
Added container_name to docker compose files

### DIFF
--- a/docker-compose/docker-compose-ce-postgresql.yaml
+++ b/docker-compose/docker-compose-ce-postgresql.yaml
@@ -2,6 +2,7 @@ version: '3.7'
 services:
   db:
     image: postgres:latest
+    container_name: passbolt-db
     restart: unless-stopped
     environment:
       POSTGRES_DB: "passbolt"
@@ -12,6 +13,7 @@ services:
 
   passbolt:
     image: passbolt/passbolt:latest
+    container_name: passbolt
     #Alternatively you can use rootless:
     #image: passbolt/passbolt:latest-ce-non-root
     restart: unless-stopped

--- a/docker-compose/docker-compose-ce.yaml
+++ b/docker-compose/docker-compose-ce.yaml
@@ -2,6 +2,7 @@ version: '3.9'
 services:
   db:
     image: mariadb:10.3
+    container_name: passbolt-db
     restart: unless-stopped
     environment:
       MYSQL_RANDOM_ROOT_PASSWORD: "true"
@@ -13,6 +14,7 @@ services:
 
   passbolt:
     image: passbolt/passbolt:latest-ce
+    container_name: passbolt
     #Alternatively you can use rootless:
     #image: passbolt/passbolt:latest-ce-non-root
     restart: unless-stopped

--- a/docker-compose/docker-compose-dev.yml
+++ b/docker-compose/docker-compose-dev.yml
@@ -2,6 +2,7 @@ version: '3.9'
 services:
   db:
     image: mariadb:10.3
+    container_name: passbolt-db
     env_file:
       - env/mysql.env
     volumes:
@@ -15,6 +16,7 @@ services:
       dockerfile: dev/Dockerfile
       args:
         PECL_PASSBOLT_EXTENSIONS: "redis gnupg xdebug"
+    container_name: passbolt
     depends_on:
       - db
     env_file:

--- a/docker-compose/docker-compose-pro.yaml
+++ b/docker-compose/docker-compose-pro.yaml
@@ -2,6 +2,7 @@ version: '3.9'
 services:
   db:
     image: mariadb:10.3
+    container_name: passbolt-db
     restart: unless-stopped
     environment:
       MYSQL_RANDOM_ROOT_PASSWORD: "true"
@@ -13,6 +14,7 @@ services:
 
   passbolt:
     image: passbolt/passbolt:latest-pro
+    container_name: passbolt
     #Alternatively you can use rootless:
     #image: passbolt/passbolt:latest-pro-non-root
     restart: unless-stopped


### PR DESCRIPTION
Added container_name to docker compose files to make the initial docker documentation working again. Because docker exec command is assuming that the container is named passbolt, but when using docker compose the container name is service-conrainer-number eg: passbolt-passbolt-1.

With this change the container is named passbolt as stated in the documentation.