### PR TITLE
Update docker-compose-pro.yaml - MariaDB update

### DIFF
--- a/docker-compose/docker-compose-pro.yaml
+++ b/docker-compose/docker-compose-pro.yaml
@@ -1,7 +1,7 @@
 version: '3.9'
 services:
   db:
-    image: mariadb:10.3
+    image: mariadb:10.10
     restart: unless-stopped
     environment:
       MYSQL_RANDOM_ROOT_PASSWORD: "true"


### PR DESCRIPTION
Would you consider bumping the MariaDB container to a recent version (e.g. 10.10 or latest) instead of pinning it to the 10.3 release?