### PR TITLE
Allow SHA1 overwrite from build_args

### DIFF
--- a/debian/Dockerfile.rootless
+++ b/debian/Dockerfile.rootless
@@ -3,6 +3,8 @@ FROM debian:bullseye-slim
 LABEL maintainer="Passbolt SA <contact@passbolt.com>"
 
 ARG SUPERCRONIC_ARCH=amd64
+ARG SUPERCRONIC_SHA1SUM=048b95b48b708983effb2e5c935a1ef8483d9e3e
+
 ARG PASSBOLT_DISTRO="buster"
 ARG PASSBOLT_COMPONENT="stable"
 ARG PASSBOLT_SERVER_KEY="hkps://keys.mailvelope.com "
@@ -15,8 +17,7 @@ ENV PHP_VERSION=7.4
 ENV GNUPGHOME=/var/lib/passbolt/.gnupg
 ENV SUPERCRONIC_VERSION=0.1.12
 ENV SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v${SUPERCRONIC_VERSION}/supercronic-linux-${SUPERCRONIC_ARCH} \
-    SUPERCRONIC=supercronic-linux-${SUPERCRONIC_ARCH} \
-    SUPERCRONIC_SHA1SUM=048b95b48b708983effb2e5c935a1ef8483d9e3e
+    SUPERCRONIC=supercronic-linux-${SUPERCRONIC_ARCH}
 ENV PASSBOLT_FLAVOUR="${PASSBOLT_FLAVOUR}"
 
 RUN apt-get update \


### PR DESCRIPTION
Indirectly solves #184 
You can already use Passbolt as rootful container, if you simply use ´build: dockerfile: debian/Dockerfile context: passbolt_docker/` after cloning this repo. Would be nice to add it to the build-artifacts aswell, this should atleast make it possible to also build working `rootless` articats.

Attached my example (works with `podman-compose`)

```
➜  passbolt cat docker-compose.yml
version: '3.9'

services:
  passbolt:
    build:
      dockerfile: debian/Dockerfile.rootless
      context: passbolt_docker/
      args:
        - SUPERCRONIC_ARCH=arm64
        - SUPERCRONIC_SHA1SUM=8baba3dd0b0b13552aca179f6ef10d55e5dee28b
```