### PR TITLE
Allow ports to be configured via environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,9 @@ Passbolt docker image provides several environment variables to configure differ
 | PASSBOLT_REGISTRATION_PUBLIC        | Defines if users can register                                             | false
 | PASSBOLT_SSL_FORCE                  | Redirects http to https                                                   | true
 | PASSBOLT_SECURITY_SET_HEADERS       | Send CSP Headers                                                          | true
+| PASSBOLT_WWW_PORT                   | Nginx HTTP port                                                           | 80
+| PASSBOLT_WWW_SSL_PORT               | Nginx HTTPS port                                                          | 443
+| PASSBOLT_PHP_FPM_PORT               | PHP-FPM port                                                              | 9000
 | SECURITY_SALT                       | CakePHP security salt                                                     | __SALT__
 
 For more env variables supported please check [default.php](https://github.com/passbolt/passbolt_api/blob/master/config/default.php)

--- a/dev/bin/docker-entrypoint.sh
+++ b/dev/bin/docker-entrypoint.sh
@@ -137,4 +137,23 @@ fi
 
 install
 
+## replace nginx config
+PASSBOLT_WWW_PORT="${PASSBOLT_WWW_PORT:-80}"
+PASSBOLT_WWW_SSL_PORT="${PASSBOLT_WWW_SSL_PORT:-443}"
+NGINX_SOURCEFILE=/etc/nginx/conf.d/default.conf
+sed -i 's/listen[ \t]*80[^0-9]*$/listen 80; #www/g' "$NGINX_SOURCEFILE"
+sed -i 's/listen[ \t]*443[^0-9]*$/listen 443; #ssl/g' "$NGINX_SOURCEFILE"
+sed -i 's/listen.*#www$/listen '"$PASSBOLT_WWW_PORT"'; #www/g' "$NGINX_SOURCEFILE"
+sed -i 's/listen.*#ssl$/listen '"$PASSBOLT_WWW_SSL_PORT"'; #ssl/g' "$NGINX_SOURCEFILE"
+echo "ready - changed port from  80 to $PASSBOLT_WWW_PORT"
+echo "ready - changed port from 443 to $PASSBOLT_WWW_SSL_PORT"
+
+## replace php-fpm config
+PASSBOLT_PHP_FPM_PORT="${PASSBOLT_PHP_FPM_PORT:-9000}"
+PHPFPM_SOURCEFILE=/usr/local/etc/php-fpm.d/
+for i in ${PHPFPM_SOURCEFILE}/*; do sed -i 's/listen .*$/listen = 127.0.0.1:'"$PASSBOLT_PHP_FPM_PORT"'/g' "$i"; done
+sed -i 's/fastcgi_pass.*$/fastcgi_pass 127.0.0.1:'"$PASSBOLT_PHP_FPM_PORT"';/g' "$NGINX_SOURCEFILE"
+echo "ready - changed php-fpm port from 9000 to $PASSBOLT_WWW_PORT"
+## //
+
 exec /usr/bin/supervisord -n


### PR DESCRIPTION
This PR solves a very homeopathic problem with shared networks on docker (in this case: pods in podman, or, in this very special case: networking via `pasta` in a `pod` with `podman` where other containers already use up the ports requested by the passbolt container).

Sadly I was not aware if we need to add the changes over at root-level `scripts/` aswell, I only saw them taking effect in the `dev/bin` docker-entrypoint.

The change itself should be fairly self-explainatory, I check the 3 variables and set the ports with some `sed` replacements in the `nginx/conf.d/default.conf` and the `/usr/local/etc/php-fpm.d/www.conf` pool config.

Tested locally, but YMMV.