### PR TITLE
Add php-pgsql for postgresql compatibility

### DIFF
--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -24,6 +24,7 @@ RUN apt-get update \
   && DEBIAN_FRONTEND=non-interactive apt-get -y install --no-install-recommends \
   nginx \
   $PASSBOLT_PKG \
+  php-pgsql \
   supervisor \
   curl \
   && rm -f /etc/passbolt/jwt/* \

--- a/debian/Dockerfile.rootless
+++ b/debian/Dockerfile.rootless
@@ -30,6 +30,7 @@ RUN apt-get update \
     && DEBIAN_FRONTEND=non-interactive apt-get -y install --no-install-recommends \
     nginx \
     $PASSBOLT_PKG \
+    php-pgsql \
     supervisor \
     curl \
     && rm -f /etc/passbolt/jwt/* \


### PR DESCRIPTION
As requested [in this community post](https://community.passbolt.com/t/postgresql-is-now-supported-experimental/5033/6), docker images should have php-pgsql package installed for postgresql compatibility.