### PR TITLE
Added HTTPS Support

### DIFF
--- a/docker-compose/docker-compose-ce.yaml
+++ b/docker-compose/docker-compose-ce.yaml
@@ -1,3 +1,5 @@
+# Added HTTPS Support with ❤ by Deltwin
+
 version: "3.9"
 services:
   db:
@@ -36,12 +38,26 @@ services:
         "--",
         "/docker-entrypoint.sh",
       ]
-    ports:
-      - 80:80
-      - 443:443
     #Alternatively for non-root images:
     # - 80:8080
     # - 443:4433
+    
+  #Updated by Deltwin
+  caddy:
+    image: caddy:2
+    container_name: caddy
+    restart: always
+    ports:
+      - 80:80  # Needed for the ACME HTTP-01 challenge.
+      - 443:443
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - ./caddy-config:/config
+      - ./caddy-data:/data
+    environment:
+      DOMAIN: "https://passbolt.local"  # Your domain.
+      EMAIL: "test@test.com"  # The email address to use for auto-renew
+      LOG_FILE: "/data/access.log"
 
 volumes:
   database_volume:


### PR DESCRIPTION
### Added fully functional HTTPS Support.

**Guide:**

In docker-compose-ce.yml:

`environment:
      DOMAIN: "https://passbolt.local"  # Your domain.
      EMAIL: "test@test.com"  # The email address to use for auto-renew
      LOG_FILE: "/data/access.log"`

**Edit DOMAIN and EMAIL values with yours.**

After editing these values, create another file called **Caddyfile** and insert this code:

`
{$DOMAIN}:443 {
  log {
    level INFO
    output file {$LOG_FILE} {
      roll_size 10MB
      roll_keep 10
    }
  }
  tls {$EMAIL}
  encode gzip
  reverse_proxy passbolt:80 {
       header_up X-Real-IP {remote_host}
  }
}
`

**You can just copy the file that I've uploaded in this commits and use as docker-compose-ce.yml** 👍🏻 Remember to create the **Caddyfile**