### PR TITLE
feat: add oci annotations to container images

### DIFF
--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -1,6 +1,13 @@
 FROM debian:bookworm-slim
 
 LABEL maintainer="Passbolt SA <contact@passbolt.com>"
+LABEL org.opencontainers.image.description="Passbolt CE Backend, a JSON API written with CakePHP"
+LABEL org.opencontainers.image.documentation=https://help.passbolt.com/
+LABEL org.opencontainers.image.authors="Passbolt SA <contact@passbolt.com>"
+LABEL org.opencontainers.image.licenses=AGPL-3.0-only
+LABEL org.opencontainers.image.source=https://github.com/passbolt/passbolt_api
+LABEL org.opencontainers.image.title=passbolt/passbolt
+LABEL org.opencontainers.image.url=https://github.com/passbolt/passbolt_docker
 
 ARG PASSBOLT_DISTRO="buster"
 ARG PASSBOLT_COMPONENT="stable"

--- a/debian/Dockerfile.rootless
+++ b/debian/Dockerfile.rootless
@@ -1,6 +1,13 @@
 FROM debian:bookworm-slim
 
 LABEL maintainer="Passbolt SA <contact@passbolt.com>"
+LABEL org.opencontainers.image.description="Passbolt CE Backend, a JSON API written with CakePHP"
+LABEL org.opencontainers.image.documentation=https://help.passbolt.com/
+LABEL org.opencontainers.image.authors="Passbolt SA <contact@passbolt.com>"
+LABEL org.opencontainers.image.licenses=AGPL-3.0-only
+LABEL org.opencontainers.image.source=https://github.com/passbolt/passbolt_api
+LABEL org.opencontainers.image.title=passbolt/passbolt
+LABEL org.opencontainers.image.url=https://github.com/passbolt/passbolt_docker
 
 ARG SUPERCRONIC_ARCH=amd64
 ARG SUPERCRONIC_SHA1SUM=642f4f5a2b67f3400b5ea71ff24f18c0a7d77d49

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -3,6 +3,13 @@ FROM composer:2.4 AS composer
 FROM php:8.1-fpm
 
 LABEL maintainer="Passbolt SA <contact@passbolt.com>"
+LABEL org.opencontainers.image.description="Passbolt CE Backend, a JSON API written with CakePHP"
+LABEL org.opencontainers.image.documentation=https://help.passbolt.com/
+LABEL org.opencontainers.image.authors="Passbolt SA <contact@passbolt.com>"
+LABEL org.opencontainers.image.licenses=AGPL-3.0-only
+LABEL org.opencontainers.image.source=https://github.com/passbolt/passbolt_api
+LABEL org.opencontainers.image.title=passbolt/passbolt
+LABEL org.opencontainers.image.url=https://github.com/passbolt/passbolt_docker
 
 ARG PASSBOLT_VERSION="3.8.3"
 ARG PASSBOLT_URL="https://github.com/passbolt/passbolt_api/archive/v${PASSBOLT_VERSION}.tar.gz"


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
Please make sure that containers being built have the proper [OCI annotations](https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys) added:

This can be added by the [docker-metadata](https://github.com/docker/metadata-action) action if you guys are using that.

A bit unsure of the description.  Taking suggestions.

**Describe the solution you'd like**
Making sure that tags like these are added to the image:
```
  org.opencontainers.image.created=2023-07-08T19:52:41.761Z
  org.opencontainers.image.description=reveal.js on steroids! Get beautiful reveal.js presentations from any Markdown file
  org.opencontainers.image.licenses=MIT
  org.opencontainers.image.revision=3fed7dbe6a05715a22edc3a03869b869b49b824a
  org.opencontainers.image.source=https://github.com/webpro/reveal-md
  org.opencontainers.image.title=reveal-md
  org.opencontainers.image.url=https://github.com/webpro/reveal-md
  org.opencontainers.image.version=5.5.1
```

**Describe alternatives you've considered**
N/A.

**Additional context**
The reason for why I want for you to add these, is that e.g. [Renovate Bot ](https://github.com/apps/renovate) is able to lookup `org.opencontainers.image.source` for where to look for the changelog to be included in a pull request.
