### PR TITLE
Added uid and gid ARG to Dockerfile.rootless

### DIFF
--- a/debian/Dockerfile.rootless
+++ b/debian/Dockerfile.rootless
@@ -12,6 +12,9 @@ ARG PASSBOLT_FLAVOUR="ce"
 ARG PASSBOLT_PKG=passbolt-$PASSBOLT_FLAVOUR-server
 ARG PASSBOLT_REPO_URL="https://download.passbolt.com/$PASSBOLT_FLAVOUR/debian"
 
+ARG PASSBOLT_USER_UID=33
+ARG PASSBOLT_GROUP_GID=33
+
 ENV PASSBOLT_PKG_KEY=0xDE8B853FC155581D
 ENV PHP_VERSION=8.2
 ENV GNUPGHOME=/var/lib/passbolt/.gnupg
@@ -19,6 +22,9 @@ ENV SUPERCRONIC_VERSION=0.2.25
 ENV SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v${SUPERCRONIC_VERSION}/supercronic-linux-${SUPERCRONIC_ARCH} \
     SUPERCRONIC=supercronic-linux-${SUPERCRONIC_ARCH}
 ENV PASSBOLT_FLAVOUR="${PASSBOLT_FLAVOUR}"
+
+RUN usermod -u $PASSBOLT_USER_UID www-data \
+    && groupmod -g $PASSBOLT_GROUP_GID www-data
 
 RUN apt-get update \
     && DEBIAN_FRONTEND=non-interactive apt-get -y install \


### PR DESCRIPTION
Added ARG variables to easily set a different uid and gid for the www-data user at build.

docker-compose:
```
services:
  passbolt:
    build:
      context: .
      args:
        PASSBOLT_USER_UID: 50010
        PASSBOLT_GROUP_GID: 50010
     [...]
```

Dockerfile:
```
FROM passbolt/passbolt:latest-ce-non-root
```

I want to isolate my containers and their respective volumes as much as possible. This can be problematic with common container users such as www-data, which theoretically would have read/write permissions for other volume directories should something go wrong.

Having a simple ARG to set a custom uid and gid at build time alleviates this, while also making the creation of volume directories with correct permissions easier.