### PR TITLE
Upate OCI URL to point to https://passbolt.com

### DIFF
--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -11,7 +11,7 @@ LABEL org.opencontainers.image.authors="Passbolt SA <contact@passbolt.com>"
 LABEL org.opencontainers.image.licenses=AGPL-3.0-only
 LABEL org.opencontainers.image.source="${API_REPOSITORY}"
 LABEL org.opencontainers.image.title=passbolt/passbolt
-LABEL org.opencontainers.image.url=https://github.com/passbolt/passbolt_docker
+LABEL org.opencontainers.image.url=https://passbolt.com
 
 ARG PASSBOLT_DISTRO="buster"
 ARG PASSBOLT_COMPONENT="stable"

--- a/debian/Dockerfile.rootless
+++ b/debian/Dockerfile.rootless
@@ -11,7 +11,7 @@ LABEL org.opencontainers.image.authors="Passbolt SA <contact@passbolt.com>"
 LABEL org.opencontainers.image.licenses=AGPL-3.0-only
 LABEL org.opencontainers.image.source="${API_REPOSITORY}"
 LABEL org.opencontainers.image.title=passbolt/passbolt
-LABEL org.opencontainers.image.url=https://github.com/passbolt/passbolt_docker
+LABEL org.opencontainers.image.url=https://passbolt.com
 
 ARG SUPERCRONIC_ARCH=amd64
 ARG SUPERCRONIC_SHA1SUM=fe1a81a8a5809deebebbd7a209a3b97e542e2bcd

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -13,7 +13,7 @@ LABEL org.opencontainers.image.authors="Passbolt SA <contact@passbolt.com>"
 LABEL org.opencontainers.image.licenses=AGPL-3.0-only
 LABEL org.opencontainers.image.source="${API_REPOSITORY}"
 LABEL org.opencontainers.image.title=passbolt/passbolt
-LABEL org.opencontainers.image.url=https://github.com/passbolt/passbolt_docker
+LABEL org.opencontainers.image.url=https://passbolt.com
 
 ARG PASSBOLT_VERSION="3.8.3"
 ARG PASSBOLT_URL="https://github.com/passbolt/passbolt_api/archive/v${PASSBOLT_VERSION}.tar.gz"


### PR DESCRIPTION
I think this is more correct for what the user wants.  Not sure going to the docker source helps people.  Rather go straight to the homepage.

<img width="551" alt="Screenshot 2024-04-04 at 00 30 13" src="https://github.com/passbolt/passbolt_docker/assets/33870508/d7821393-fe79-49da-b475-fd4b2c828d45">
