### PR TITLE
Updated readme to include localhost domain-mapping setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ This registration command will return a single use url required to continue the
 web browser setup and finish the registration. Your passbolt instance should be
 available browsing `https://example.com`
 
+If you encounter a `DNS_PROBE_FINISHED_NXDOMAIN` error when deploying locally, you may need to manually edit the 
+hosts file on your machine so that the `passbolt.local` domain is resolved to your localhost ip address. On Linux, 
+append the line `127.0.0.1   passbolt.local` to your `/etc/hosts` file.
+
 # Configure passbolt
 
 ## Environment variables reference


### PR DESCRIPTION
Added information to guide users to mapping the passbolt.local domain to their localhost loopback address if they are deploying locally.

Encountered the dns_probe_finished_nxdomain error when accessing the passbolt.local url after registering a user, so thought this short instruction would improve the setup process for users

Reference: https://community.passbolt.com/t/i-can-not-access-hostname-passbolt-local/1306/2