### PR TITLE
fix: treat unset PASSBOLT_PLUGINS_JWT_AUTHENTICATION_ENABLED as true

### DIFF
--- a/scripts/entrypoint/passbolt/entrypoint.sh
+++ b/scripts/entrypoint/passbolt/entrypoint.sh
@@ -77,7 +77,9 @@ function migrate_command() {
 }
 
 function jwt_keys_creation() {
-  if [[ $PASSBOLT_PLUGINS_JWT_AUTHENTICATION_ENABLED == "true" && (! -f $passbolt_config/jwt/jwt.key || ! -f $passbolt_config/jwt/jwt.pem) ]]; then
+  if [[ (("${PASSBOLT_PLUGINS_JWT_AUTHENTICATION_ENABLED}" == "true") ||
+    (-z "${PASSBOLT_PLUGINS_JWT_AUTHENTICATION_ENABLED+xxx}")) &&
+    (! -f "$passbolt_config/jwt/jwt.key" || ! -f "$passbolt_config/jwt/jwt.pem") ]]; then
     chmod 770 "$passbolt_config/jwt"
     su -c '/usr/share/php/passbolt/bin/cake passbolt create_jwt_keys' -s /bin/bash www-data
     chmod 440 "$passbolt_config/jwt/jwt.key" && chown root:www-data "$passbolt_config/jwt/jwt.key"


### PR DESCRIPTION
**What this PR does**

Ensures the default value of `PASSBOLT_PLUGINS_JWT_AUTHENTICATION_ENABLED` (`True`) is set so that the JWT key pair is generated at container initialization. This ensures the Docker setup mirrors the default JWT authentication setup behavior found in bare-metal installations. fixes #243 

**Before**  
Keys were only generated if the env var was explicitly set to `"true"`.

**After**  
- Unset → treated as `true` (keys generated if missing)  
- Explicit `"true"` → same as before  
- `"false"` / empty / other → no generation

**Why needed**  
The default value `true` for JWT Authentication (set in `defaults.php`) does **not** apply to the bash entrypoint/healthcheck scripts in Docker images. We must explicitly mirror this default in the bash logic to match bare-metal behavior in containerized deployments.

**Changes**  
- Added unset check (`-z "${VAR+xxx}"`) to the condition  
- Added proper quoting for all variables (safer against special chars)  
- No change when the var is explicitly set